### PR TITLE
Allow I2C bus to be shared across multiple client objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target/
 Cargo.lock
+
+# MacOS
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mcp230xx"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP23008/MCP23017 8/16-Bit I2C I/O Expander with I2C Interface"
-authors = ["Luca Zulian <lucagiuggia@gmail.com>", "Robert Jördens <rj@quartiq.de>", "Norman Krackow <nk@quartiq.de>"]
+authors = ["Luca Zulian <lucagiuggia@gmail.com>", "Robert Jördens <rj@quartiq.de>", "Norman Krackow <nk@quartiq.de>", "Michael Kamprath <michael@kamprath.net>"]
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["hal", "IO", "mcp23017", "mcp23008", "I2C"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,16 @@ exclude = [
     "docs/*",
 ]
 
+[lib]
+name = "mcp230xx"
+test = false
+bench = false
+
+[features]
+shared_i2c = []
+
 [dependencies]
 embedded-hal = "0.2.3"
 bit_field = "0.10.1"
-num_enum = { version = "0.5.7", default-features = false }
+num_enum = { version = "0.7", default-features = false }
 paste = "1.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ test = false
 bench = false
 
 [features]
+# Configure the library to use a reference counted I2C bus object rather than moving the I2C bus
+# object into the MCP230xx struct. This allows the I2C bus to be shared between multiple clients. Using this
+# feature does change the API slightly, as the I2C bus object must be passed wrapped in an `&Rc<RefCell<...>>` to the
+# `new` function.
 shared_i2c = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,34 @@ assert!(u.gpio(pin).unwrap());
 
 ![Address table](docs/address-pins.jpg)
 
+### Shared I2C bus
+This library supports sharing the I2C bus with other devices. To do so, you must specify the `shared_i2c` feature in your `Cargo.toml`:
+
+```toml
+[dependencies.mcp230xx]
+version = "0.2"
+features = ["shared_i2c"]
+```
+Furthermore, you must pass the I2C bus object wrapped in an `RC<RefCell<...>>` container to the `Mcp230xx` `new` function, and if your project is an `no_std` project then to be able to
+create and `Rc<>` your project must have a global allocator and the `alloc` crate as a dependency, such as [`embedded-alloc`](https://github.com/rust-embedded/embedded-alloc).
+
+```rust
+extern crate alloc;
+
+use mcp230xx::*;
+
+// Include mcp230xx create with shared_i2c feature and declare and init your
+// global allocator at the start of program.
+
+let mut i2c = I2c::new(...);  // create your I2C bus object as per your particular HAL
+let i2c = Rc::new(RefCell::new(i2c));  // wrap it in an Rc<RefCell<...>> container
+
+let mut u = Mcp230xx<I2C, Mcp23017>::new_default(&i2c).unwrap();
+u.set_direction(pin, Direction::Output).unwrap();
+u.set_gpio(pin, Level::High).unwrap();
+assert!(u.gpio(pin).unwrap());
+```
+
 ## Documentation
 
 API Docs available on [docs.rs](https://docs.rs/mcp230xx)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,26 +264,30 @@ where
         self.address
     }
 
+    #[cfg(not(feature="shared_i2c"))]
+    /// Internal function to get a mutable reference to the I2C bus
+    fn i2c(&mut self) -> &mut I2C {
+        &mut self.i2c
+    }
+
+    #[cfg(feature="shared_i2c")]
+    /// Internal function to get a mutable reference to the I2C bus
+    fn i2c(&mut self) -> core::cell::RefMut<'_, I2C> {
+        self.i2c.borrow_mut()
+    }
+
     /// Read an 8 bit register
     pub fn read(&mut self, addr: u8) -> Result<u8, E> {
         let mut data = [0u8];
-        #[cfg(not(feature="shared_i2c"))]
-        self.i2c.write_read(self.address, &[addr], &mut data)?;
-        #[cfg(feature="shared_i2c")]
-        self.i2c.borrow_mut().write_read(self.address, &[addr], &mut data)?;
+        let address = self.address;
+        self.i2c().write_read(address, &[addr], &mut data)?;
         Ok(data[0])
     }
 
     /// Write an 8 bit register
     pub fn write(&mut self, addr: u8, data: u8) -> Result<(), E> {
-        #[cfg(not(feature="shared_i2c"))]
-        {
-            self.i2c.write(self.address, &[addr, data])
-        }
-        #[cfg(feature="shared_i2c")]
-        {
-            self.i2c.borrow_mut().write(self.address, &[addr, data])
-        }
+        let address = self.address;
+        self.i2c().write(address, &[addr, data])
     }
 
     /// Get a single bit in a register


### PR DESCRIPTION
If you have more than one I2C device on the same bus, then the driver objects for each all need to have a reference to the I2C bus object. However, how this library was originally Written, the I2C bus object is moved into the `Mcp230xx` structure and thus not usable by other I2C objects. This change adds an optional feature `shared_i2c` that changes the how the I2C bus object is retained within the `Mcp230xx` object. If the feature is not active, then this library compiles and behaves exactly. as it did before, moving the I2C bus object into the `Mcp230xx` struct. However, if the `shared_i2c` feature is active, then the I2C bus needs to be passed contained in a `Rc<RefCell<...>>`, thus allowing the I2C bus to be shared with other clients via the reference count container.  When the `shared_i2c` feature is active, that does require the project to have a global allocator defined.

While existing client code of this library should work as-is with this change, since a new feature was added that when active does change the API slightly, the version was bumped to `0.2`. 